### PR TITLE
Check for quot before using

### DIFF
--- a/pyrope/replay.py
+++ b/pyrope/replay.py
@@ -233,7 +233,8 @@ class Replay:
         if remaining.int != 0:
             msg = "There seems to be meaningful data left in the Netstream: %s" % remaining.hex
             raise EOFError(msg)
-        qout.put('done')
+        if qout:
+            qout.put('done')
         return frames
 
     def __getstate__(self):


### PR DESCRIPTION
`replay.parse_netstream()` yields:

```
Traceback (most recent call last):
  File "tester.py", line 4, in <module>
    replay.parse_netstream()
  File "/Users/cjh/src/pyrope/pyrope/replay.py", line 51, in parse_netstream
    raise e
  File "/Users/cjh/src/pyrope/pyrope/replay.py", line 45, in parse_netstream
    self.netstream = self._parse_frames(qout, ev)
  File "/Users/cjh/src/pyrope/pyrope/replay.py", line 236, in _parse_frames
    qout.put('done')
AttributeError: 'NoneType' object has no attribute 'put'
```
